### PR TITLE
Fix parse issues with multiple quote-types and escaped quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,12 @@ module.exports = function(args){
 
 	var current = null;
 	var quoted = null;
+	var quoteType = null;
 
 	function addcurrent(){
 		if(current){
-			arr.push(current);
+			// trim extra whitespace on the current arg
+			arr.push(current.trim());
 			current = null;
 		}
 	}
@@ -23,15 +25,23 @@ module.exports = function(args){
 				addcurrent();
 			}
 		}
-		else if(c=="\""){
+		else if(c == '\'' || c == '"'){
 			if(quoted){
 				quoted += c;
-				arr.push(quoted);
-				quoted = null;
+				// only end this arg if the end quote is the same type as start quote
+				if (quoteType === c) {
+					// make sure the quote is not escaped
+					if (quoted.charAt(quoted.length - 2) !== '\\') {
+						arr.push(quoted);
+						quoted = null;
+						quoteType = null;
+					}
+				}
 			}
 			else{
 				addcurrent();
 				quoted = c;
+				quoteType = c;
 			}
 		}
 		else{

--- a/test/test.js
+++ b/test/test.js
@@ -7,10 +7,23 @@ describe('spawn-args', function(){
   })
 
   it('should parse some arguments', function() {
-    var arr = parse('--host hello.com --port 80 --title "Apple Pie With Spaces" --num 20')    
+    var arr = parse('--host hello.com --port 80 --title "Apple Pie With Spaces" --num 20')
 
     arr.length.should.equal(8);
     arr[5].should.equal('"Apple Pie With Spaces"');
   })
 
+  it('should parse multiple quotes properly', function() {
+    var arr = parse('--data \'{"url": "http://example.com"}\'')
+
+    arr.length.should.equal(2);
+    arr[1].should.equal('\'{"url": "http://example.com"}\'');
+  })
+
+  it('should parse escaped quotes properly', function() {
+    var arr = parse('--data "{\\"url\\": \\"http://example.com\\"}"')
+
+    arr.length.should.equal(2);
+    arr[1].should.equal('"{\\"url\\": \\"http://example.com\\"}"');
+  })
 })


### PR DESCRIPTION
Fixed issues parsing things like `--data '{"url": "http://example.com"}'` and `--data "{\"url\": \"http://example.com\"}"`.
