### PR TITLE
Parse commands with escaped newlines properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = function(args){
 		}
 	}
 
+	// remove escaped newlines
+	args = args.replace(/\\\n/g, '');
+
 	for(var i=0; i<args.length; i++){
 		var c = args.charAt(i);
 

--- a/test/test.js
+++ b/test/test.js
@@ -26,4 +26,10 @@ describe('spawn-args', function(){
     arr.length.should.equal(2);
     arr[1].should.equal('"{\\"url\\": \\"http://example.com\\"}"');
   })
+
+  it('should parse escaped newlines properly', function() {
+    var arr = parse('--host hello.com \\\n --port 80')
+
+    arr.length.should.equal(4);
+  })
 })


### PR DESCRIPTION
Commands with escaped newlines were not parsing correctly, e.g:

```
curl -X POST \
  http://example.com/ \
  -d 'foo=bar'
```

This PR just removes escaped newlines, because they are not part of the command.
