### PR TITLE
Fixed examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ var args2 = spawnargs('-port 80 --color "red" --title "this is a title"', { remo
 	[
 		'-port',
 		'80',
+		'--color',
+		'red',
 		'--title',
 		'"this is a title"'
 	]
@@ -58,6 +60,8 @@ var args3 = spawnargs('-port 80 --color "red" --title "this is a title"', { remo
 	[
 		'-port',
 		'80',
+                '--color',
+                'red',
 		'--title',
 		'this is a title'
 	]


### PR DESCRIPTION
Fixed examples in README: `..., '--color', 'red', ...` are missing from the output values expected & produced by the last 2 samples.